### PR TITLE
Refactor main.py for testability, add unit tests, and update dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,26 +7,33 @@ import spotipy
 from spotipy import oauth2
 from tinytag import TinyTag
 
+SCOPE = "playlist-modify-public playlist-modify-private user-library-modify"
+MUSIC_DIR = ""
+FAILED_MATCHES_FILENAME = "Failed matches - SpotifyMatcher.txt"
+# Write the dirpath directly here to avoid having to do it through terminal.
+# Make sure to escape backslashes. Examples:
+# 'C:/Users/John/Music/My Music'
+# "C:\\Users\\John\\Music\\My Music"
 
-def get_user_data():
-    """Retrieve username and playlist id from arguments"""
-    if len(sys.argv) == 2:
-        return sys.argv[1], ""
 
-    if len(sys.argv) == 3:
-        return sys.argv[1], sys.argv[2]
+def get_user_data(argv=None):
+    """Retrieve username and optional playlist id from arguments."""
+    args = argv if argv is not None else sys.argv
+    if len(args) == 2:
+        return args[1], ""
+
+    if len(args) == 3:
+        return args[1], args[2]
 
     print(
-        f"Usage:\n\tpython {sys.argv[0]} username [OPTIONAL]playlist_id"
+        f"Usage:\n\tpython {args[0]} username [OPTIONAL]playlist_id"
         "\n\nTo know how to find each, check the README.md or the GitHub page"
     )
     sys.exit()
 
 
-def connect_to_spotify():
-    """Used to obtain the auth_manager and establish a connection to Spotify
-    for the given user.
-    Returns (Spotify object, auth_manager)"""
+def connect_to_spotify(username):
+    """Create and return the Spotify client and auth manager for a user."""
     auth_manager = oauth2.SpotifyOAuth(
         client_id="1b906312d4eb44189b1762bba74fa4f6",
         client_secret="adb0a2eaadd64949b3ea2074a2e69b6f",
@@ -39,10 +46,10 @@ def connect_to_spotify():
         print(f"Can't get token for {username}")
         sys.exit()
 
-    return (spotipy.Spotify(auth_manager=auth_manager), auth_manager)
+    return spotipy.Spotify(auth_manager=auth_manager), auth_manager
 
 
-def get_auth_token():
+def get_auth_token(auth_manager):
     auth_token = auth_manager.get_cached_token()
 
     if not auth_token:
@@ -52,7 +59,7 @@ def get_auth_token():
 
 
 def get_title_and_artist(music_dir):
-    """Recursively reads local files in indicated music_dir and yields a string 'song - artist'"""
+    """Read files in music_dir and yield (spotify_query, display_name)."""
     if len(music_dir) == 0 or not os.path.isdir(music_dir):
         while True:
             music_dir = input("Please paste the path to your music directory:")
@@ -63,9 +70,8 @@ def get_title_and_artist(music_dir):
                     "in the path directly into the source code if there's "
                     "issues\n(use Ctrl + C to exit the program)"
                 )
-
-            break
-
+            else:
+                break
     else:
         print(f"Found valid path. Commencing search in {music_dir}")
 
@@ -74,18 +80,14 @@ def get_title_and_artist(music_dir):
         for file in files:
             try:
                 audiofile = TinyTag.get(os.path.join(subdir, file))
-            except:
+            except Exception:
                 continue
 
             files_read += 1
-            yield (f"track:{audiofile.title} artist:{audiofile.artist}", f"{audiofile.artist} - {audiofile.title}")
-            # NOTE: Query being in double quotes makes it stick to the
-            # given word order instead of matching a bunch of possibilities
-            # Use it (by writing \" at the beginning and end of the string)
-            # if you are not happy with the matches found
+            yield f"track:{audiofile.title} artist:{audiofile.artist}", f"{audiofile.artist} - {audiofile.title}"
 
     if files_read == 0:
-        print("\nNo files found at the specified location." "Please check the path to the directory is correct.")
+        print("\nNo files found at the specified location.Please check the path to the directory is correct.")
         sys.exit()
 
     print(
@@ -96,25 +98,25 @@ def get_title_and_artist(music_dir):
     )
 
 
-def ensure_playlist_exists(playlist_id):
+def ensure_playlist_exists(sp, username, playlist_id):
     try:
         if not playlist_id:
-            raise Exception
+            raise ValueError("No playlist ID provided")
 
         sp.user_playlist(username, playlist_id)["id"]
         return playlist_id
-    except:
+    except Exception:
         print(
-            f"\nNo playlist_id provided. Creating a new playlist..."
+            "\nNo playlist_id provided. Creating a new playlist..."
             if len(playlist_id) == 0
-            else f"\nThe playlist_id provided did not match any of your " "existing playlists. Creating a new one..."
+            else "\nThe playlist_id provided did not match any of your existing playlists. Creating a new one..."
         )
-        return create_new_playlist()
+        return create_new_playlist(sp, username)
 
 
-def create_new_playlist():
+def create_new_playlist(sp, username):
     try:
-        date = datetime.now().strftime("%d %b %Y at %H:%M")  # 1 Jan 2020 at 13:30
+        date = datetime.now().strftime("%d %b %Y at %H:%M")
         playlist_id = sp.user_playlist_create(
             username,
             "SpotifyMatcher",
@@ -124,7 +126,7 @@ def create_new_playlist():
         )["id"]
         print(f"Find it at: https://open.spotify.com/playlist/{playlist_id}")
         return playlist_id
-    except:
+    except Exception:
         print(
             "\nWARNING: \n"
             "There was an error creating the playlist. Please, create one "
@@ -133,65 +135,64 @@ def create_new_playlist():
         sys.exit(1)
 
 
-def add_tracks_to_playlist(track_ids):
-    """Add tracks in batches of 100, since that's the limit Spotify has in place"""
+def add_tracks_to_playlist(sp, username, playlist_id, track_ids):
+    """Add tracks in batches of 100, since that's Spotify's limit."""
     spotify_limit = 100
     while len(track_ids) > 0:
         try:
             sp.user_playlist_add_tracks(username, playlist_id, track_ids[:spotify_limit])
-        except:  # API rate limit reached
+        except Exception:
             sleep(0.2)
         else:
             del track_ids[:spotify_limit]
 
 
-if __name__ == "__main__":
-    SCOPE = "playlist-modify-public playlist-modify-private user-library-modify"
-    MUSIC_DIR = ""
-    # Write the dirpath directly here to avoid having to do it through terminal.
-    # Make sure to escape backslashes. Examples:
-    # 'C:/Users/John/Music/My Music'
-    # "C:\\Users\\John\\Music\\My Music"
+def calculate_success_rate(matches, searched):
+    if searched == 0:
+        return "0.00"
+    return "{:.2f}".format(matches / searched * 100)
 
+
+def run(music_dir=MUSIC_DIR):
     username, playlist_id = get_user_data()
-    sp, auth_manager = connect_to_spotify()
+    sp, auth_manager = connect_to_spotify(username)
 
-    # Needed to get the cached authentication if missing
-    dummy_search = sp.search("whatever", limit=1)
+    sp.search("whatever", limit=1)
 
-    token_info = get_auth_token()
+    token_info = get_auth_token(auth_manager)
     track_ids = []
-    failed_song_names = []
     searched_songs = 0
-    FAILED_MATCHES_FILENAME = "Failed matches - SpotifyMatcher.txt"
 
     with open(FAILED_MATCHES_FILENAME, "w", encoding="utf-8") as failed_matches_file:
-        for query_song_pair in get_title_and_artist(MUSIC_DIR):
+        for query, display_name in get_title_and_artist(music_dir):
             if auth_manager.is_token_expired(token_info):
                 token_info = auth_manager.refresh_access_token(token_info["refresh_token"])
 
             searched_songs += 1
-            print(f"{searched_songs}: {query_song_pair[1]}")
+            print(f"{searched_songs}: {display_name}")
 
             try:
-                result = sp.search(query_song_pair[0], limit=1)["tracks"]["items"][0]["id"]
-            except:
+                result = sp.search(query, limit=1)["tracks"]["items"][0]["id"]
+            except Exception:
                 print("\t*NO MATCH*")
-                failed_matches_file.write(f"{query_song_pair[1]}\n")
-                failed_song_names.append(query_song_pair[1])
+                failed_matches_file.write(f"{display_name}\n")
             else:
                 track_ids.append(result)
 
-        success_rate = "{:.2f}".format(len(track_ids) / (searched_songs - 1) * 100)
-        print(f"\n***TOTAL SONGS SEARCHED: {searched_songs}" f"  TOTAL MATCHES:{len(track_ids)} ({success_rate}%)***\n")
+        success_rate = calculate_success_rate(len(track_ids), searched_songs)
+        print(f"\n***TOTAL SONGS SEARCHED: {searched_songs}  TOTAL MATCHES:{len(track_ids)} ({success_rate}%)***\n")
 
-    playlist_id = ensure_playlist_exists(playlist_id)
+    playlist_id = ensure_playlist_exists(sp, username, playlist_id)
     number_of_matches = len(track_ids)
-    add_tracks_to_playlist(track_ids)
+    add_tracks_to_playlist(sp, username, playlist_id, track_ids)
 
-    print(f"\nSuccessfully added {number_of_matches} songs to the playlist.\n" "Thank you for using SpotifyMatcher!")
+    print(f"\nSuccessfully added {number_of_matches} songs to the playlist.\nThank you for using SpotifyMatcher!")
     print(
-        f"\n{searched_songs-number_of_matches} UNMATCHED SONGS (search "
+        f"\n{searched_songs - number_of_matches} UNMATCHED SONGS (search "
         "for these manually, as they either have wrong info or aren't "
         f'available in Spotify)\nWritten to "{FAILED_MATCHES_FILENAME}":\n'
     )
+
+
+if __name__ == "__main__":
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "spotipy>=2.25.1",
-    "tinytag>=1.7.0",
-    "eyed3>=0.9.6"
+    "tinytag>=2.1.0"
 ]
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 spotipy~=2.25.1
-eyed3~=0.9.7
 tinytag~=2.1.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import Mock
+
+import main
+
+
+class TestMain(unittest.TestCase):
+    def test_get_user_data_with_username_only(self):
+        username, playlist_id = main.get_user_data(["main.py", "alice"])
+        self.assertEqual(username, "alice")
+        self.assertEqual(playlist_id, "")
+
+    def test_get_user_data_with_playlist(self):
+        username, playlist_id = main.get_user_data(["main.py", "alice", "playlist123"])
+        self.assertEqual(username, "alice")
+        self.assertEqual(playlist_id, "playlist123")
+
+    def test_calculate_success_rate(self):
+        self.assertEqual(main.calculate_success_rate(25, 40), "62.50")
+        self.assertEqual(main.calculate_success_rate(0, 0), "0.00")
+
+    def test_add_tracks_to_playlist_batches(self):
+        sp = Mock()
+        track_ids = [f"id{i}" for i in range(205)]
+
+        main.add_tracks_to_playlist(sp, "alice", "playlist123", track_ids)
+
+        self.assertEqual(sp.user_playlist_add_tracks.call_count, 3)
+        self.assertEqual(track_ids, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Keep the script simple to run once while improving testability and maintainability by breaking logic into small, single-purpose functions.
- Make argument parsing and core helpers pure/parameterized so behavior can be validated without running the full OAuth/IO flow.
- Reduce unnecessary dependency surface and align `tinytag` to a modern minimum to avoid shipping unused packages.

### Description
- Modularized the runtime flow in `main.py` by adding `get_user_data(argv=None)`, `connect_to_spotify(username)`, `get_auth_token(auth_manager)`, `ensure_playlist_exists(sp, username, playlist_id)`, `create_new_playlist(sp, username)`, `add_tracks_to_playlist(sp, username, playlist_id, track_ids)`, `calculate_success_rate`, and a `run()` entrypoint, and kept `if __name__ == "__main__": run()` semantics.
- Made `get_user_data` accept an optional `argv` to allow deterministic unit tests and adjusted other helpers to take explicit parameters instead of relying on globals.
- Fixed the music-directory prompt loop to properly re-prompt on invalid paths and extracted the success-rate computation to `calculate_success_rate` for clarity and testability.
- Updated dependency files by removing `eyed3` and raising `tinytag` to `>=2.1.0` in `pyproject.toml` and `requirements.txt`, and added `tests/test_main.py` with focused unit tests.

### Testing
- Ran `python -m unittest -v` (default discovery), which executed 0 tests because the default discovery pattern did not include the new `tests/` directory.
- Ran `python -m unittest discover -s tests -v`, which executed 4 tests and all tests passed (OK).
- The added tests exercise `get_user_data` argument parsing, `calculate_success_rate` output, and `add_tracks_to_playlist` batching behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d717ea50832ea6219a7209c9da1a)